### PR TITLE
Fix wrong result checking on staticpress fetch.

### DIFF
--- a/includes/StaticPress_Command.class.php
+++ b/includes/StaticPress_Command.class.php
@@ -53,11 +53,10 @@ if (class_exists('WP_CLI_Command')) {
             do {
                 $processRun = WP_CLI::launch_self('staticpress fetch', array(), array(), true, true);
                 $result = json_decode($processRun->stdout);
-                if (!$result->result) {
-                    WP_CLI::error('Fetch failed.');
-                }
-                foreach ($result->files as $file) {
-                    WP_CLI::log($file->url);
+                if ($result->result) {
+                    foreach ($result->files as $file) {
+                        WP_CLI::log($file->url);
+                    }
                 }
             } while($result->final === false);
 


### PR DESCRIPTION
## 概要

 静的変換対象の URL 数が特定条件の場合、内部的に正常に Fetch 処理が成功しているのに 、WP-CLI から実行した StaticPress Auto Builder の処理結果が `Fetch failed.` となる不具合に対応しました。

### 例: 2 回目以降の再構築時かつ静的変換対象の URL 数が 10 件の場合

各回の `static_press::ajax_fetch()`  の結果は以下のようになる。

https://github.com/megumiteam/staticpress/blob/master/includes/class-static_press.php#L232

```
# 1回目
$result = array('result' => true, 'files' => (5件), 'final' => false);

# 2回目
$result = array('result' => true, 'files' => (5件), 'final' => false);
```

https://github.com/megumiteam/staticpress/blob/master/includes/class-static_press.php#L174

```
# 3回目
$result = array('result' => false, 'final' => true);
```

ここで、`$result->result == false` となり、StaticPress 的には `ajax_fetch()` が正常終了するが、StaticPress Auto Builder 的には失敗判定となってしまう。

## 変更内容

[`StaticPress_Command::build()` の Fetch 結果判定部分](https://github.com/yujiod/cron-staticpress/blob/master/includes/StaticPress_Command.class.php#L56) における `$result->result` の解釈を [StaticPress 本体側の解釈](https://github.com/megumiteam/staticpress/blob/master/includes/class-static_press_admin.php#L302) と同様になるように変更しました。

- 変更前: `static_press::ajax_fetch()` の  処理成否
- 変更後: 1 回の `static_press::ajax_fetch()` コール内で静的変換したファイル  の有無
